### PR TITLE
Add background color decoration to code blocks

### DIFF
--- a/lib/shiki-plugin.ts
+++ b/lib/shiki-plugin.ts
@@ -43,6 +43,14 @@ function getDecorations({
       ? theme
       : highlighter.getLoadedThemes()[0]
 
+    const themeResolved = highlighter.getTheme(themeToApply)
+
+    decorations.push(
+      Decoration.node(block.pos, block.pos + block.node.nodeSize, {
+        style: `background-color: ${themeResolved.bg}`,
+      }),
+    )
+
     const tokens = highlighter.codeToTokensBase(block.node.textContent, {
       lang: language,
       theme: themeToApply,

--- a/lib/tests/code-block-shiki.test.ts
+++ b/lib/tests/code-block-shiki.test.ts
@@ -32,9 +32,9 @@ it('initializes tiptap with the codeblock', async () => {
   })
 
   expect(mount.innerHTML).toMatchInlineSnapshot(`
-    "<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><p>Hello World!</p><pre><code class="language-ts"><span style="color: #BB9AF7;">function</span><span style="color: #A9B1D6;"> </span><span style="color: #7AA2F7;">foo</span><span style="color: #9ABDF5;">()</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
+    "<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><p>Hello World!</p><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #BB9AF7;">function</span><span style="color: #A9B1D6;"> </span><span style="color: #7AA2F7;">foo</span><span style="color: #9ABDF5;">()</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
     <span style="color: #9ABDF5;">  </span><span style="color: #BB9AF7;">return</span><span style="color: #9ABDF5;"> </span><span style="color: #89DDFF;">'</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">'</span>
-    <span style="color: #9ABDF5;">}</span></code></pre><pre><code class="language-css"><span style="color: #E0AF68;">.</span><span style="color: #9ECE6A;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
+    <span style="color: #9ABDF5;">}</span></code></pre><pre style="background-color: #1a1b26;"><code class="language-css"><span style="color: #E0AF68;">.</span><span style="color: #9ECE6A;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
     <span style="color: #9ABDF5;">  </span><span style="color: #7AA2F7;">color</span><span style="color: #89DDFF;">:</span><span style="color: #9ABDF5;"> </span><span style="color: #FF9E64;">green</span><span style="color: #89DDFF;">;</span>
     <span style="color: #9ABDF5;">}</span></code></pre></div>"
   `)
@@ -66,9 +66,9 @@ it('highlights code with #setContent', async () => {
   })
 
   expect(mount.innerHTML).toMatchInlineSnapshot(`
-    "<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><p>Hello World!</p><pre><code class="language-ts"><span style="color: #BB9AF7;">function</span><span style="color: #A9B1D6;"> </span><span style="color: #7AA2F7;">foo</span><span style="color: #9ABDF5;">()</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
+    "<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><p>Hello World!</p><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #BB9AF7;">function</span><span style="color: #A9B1D6;"> </span><span style="color: #7AA2F7;">foo</span><span style="color: #9ABDF5;">()</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
     <span style="color: #9ABDF5;">  </span><span style="color: #BB9AF7;">return</span><span style="color: #9ABDF5;"> </span><span style="color: #89DDFF;">'</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">'</span>
-    <span style="color: #9ABDF5;">}</span></code></pre><pre><code class="language-css"><span style="color: #E0AF68;">.</span><span style="color: #9ECE6A;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
+    <span style="color: #9ABDF5;">}</span></code></pre><pre style="background-color: #1a1b26;"><code class="language-css"><span style="color: #E0AF68;">.</span><span style="color: #9ECE6A;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #9ABDF5;">{</span>
     <span style="color: #9ABDF5;">  </span><span style="color: #7AA2F7;">color</span><span style="color: #89DDFF;">:</span><span style="color: #9ABDF5;"> </span><span style="color: #FF9E64;">green</span><span style="color: #89DDFF;">;</span>
     <span style="color: #9ABDF5;">}</span></code></pre></div>"
   `)
@@ -93,7 +93,7 @@ it('highlights content with #toggleCodeBlock', async () => {
   })
 
   expect(mount.innerHTML).toMatchInlineSnapshot(
-    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">=</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">'</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">'</span></code></pre></div>"`,
+    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">=</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">'</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">'</span></code></pre></div>"`,
   )
 })
 
@@ -120,23 +120,23 @@ it('highlights code while typing', async () => {
   })
 
   expect(mount.innerHTML).toMatchInlineSnapshot(
-    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre><code class="language-ts"><span style="color: #9D7CD8;">const</span></code></pre></div>"`,
+    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #9D7CD8;">const</span></code></pre></div>"`,
   )
 
   editor.commands.insertContent(' foo')
   expect(mount.innerHTML).toMatchInlineSnapshot(
-    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span></code></pre></div>"`,
+    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span></code></pre></div>"`,
   )
 
   editor.commands.insertContent(' = "bar"')
   expect(mount.innerHTML).toMatchInlineSnapshot(
-    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">=</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">"</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">"</span></code></pre></div>"`,
+    `"<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">=</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">"</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">"</span></code></pre></div>"`,
   )
 
   editor.commands.insertContent(`;
 console.log('hello')`)
   expect(mount.innerHTML).toMatchInlineSnapshot(`
-    "<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">=</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">"</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">"</span><span style="color: #89DDFF;">;</span>
+    "<div contenteditable="true" translate="no" tabindex="0" class="tiptap ProseMirror"><pre style="background-color: #1a1b26;"><code class="language-ts"><span style="color: #9D7CD8;">const</span><span style="color: #A9B1D6;"> </span><span style="color: #BB9AF7;">foo</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">=</span><span style="color: #A9B1D6;"> </span><span style="color: #89DDFF;">"</span><span style="color: #9ECE6A;">bar</span><span style="color: #89DDFF;">"</span><span style="color: #89DDFF;">;</span>
     <span style="color: #C0CAF5;">console</span><span style="color: #89DDFF;">.</span><span style="color: #7AA2F7;">log</span><span style="color: #9ABDF5;">(</span><span style="color: #89DDFF;">'</span><span style="color: #9ECE6A;">hello</span><span style="color: #89DDFF;">'</span><span style="color: #9ABDF5;">)</span></code></pre></div>"
   `)
 })


### PR DESCRIPTION
Thank you so extension for this plugin! It really helps me solve the integration issues with shiki. However, I noticed that the highlighting doesn’t include background colors. For code highlighting scenarios, I think it’s unreasonable to expect developers to manually modify the pre tag’s background color, as it can’t guarantee full compatibility with shiki’s highlighting styles. Plus, every time we change the shiki theme, we’d potentially need to adjust the pre background color accordingly, not to mention dealing with both dark and light theme variants.

So this PR adds the shiki-generated background color to the pre tag.

video demo:


https://github.com/user-attachments/assets/f380aeb6-3666-4537-bc3c-1e8914b485b8

