### PR TITLE
Expand peer dependency support for TipTap v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "@tiptap/core": "^2.3.0",
-    "@tiptap/extension-code-block": "^2.3.0",
-    "@tiptap/pm": "^2.3.0",
+    "@tiptap/core": "^2.3.0 || ^3.0.0",
+    "@tiptap/extension-code-block": "^2.3.0 || ^3.0.0",
+    "@tiptap/pm": "^2.3.0 || ^3.0.0",
     "shiki": "^3.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Bump the tiptap version in peerDependencies. I’ve tested this extension with Tiptap v3 and haven’t encountered any errors, so I think we can bump it to 3.0.0.