### PR TITLE
Remove core from bundled dependencies and codeblock from peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@tiptap/core": "^2.3.0 || ^3.0.0",
-    "@tiptap/extension-code-block": "^2.3.0 || ^3.0.0",
     "@tiptap/pm": "^2.3.0 || ^3.0.0",
     "shiki": "^3.0.0"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
       fileName: pkg.name,
     },
     rollupOptions: {
-      external: [/@tiptap\/pm\/.*/, 'shiki'],
+      external: [/@tiptap\/pm\/.*/, '@tiptap/core', 'shiki'],
     },
   },
   plugins: [


### PR DESCRIPTION
- Treat `@tiptap/core` as a peer dependency, do not bundle it
- Do not treat `@tiptap/extension-code-block`, bundle it

I noticed the bundle size grew after the latest upgrade to ^3 due to increase in `@tiptap/core`. It shouldn't be bundled, it's a peer dependency