### PR TITLE
Support custom non-bundled Shiki themes

### DIFF
--- a/lib/code-block-shiki.ts
+++ b/lib/code-block-shiki.ts
@@ -1,12 +1,13 @@
 import CodeBlock, { type CodeBlockOptions } from '@tiptap/extension-code-block'
-import type { BundledLanguage, BundledTheme } from 'shiki'
+import type { BundledLanguage, BundledTheme, ThemeRegistration } from 'shiki'
 
 import { ShikiPlugin } from './shiki-plugin.ts'
 
 /* v8 ignore start -- @preserve */
 export interface CodeBlockShikiOptions extends CodeBlockOptions {
   defaultLanguage: BundledLanguage | null | undefined
-  defaultTheme: BundledTheme
+  // `(string & {})` preserves IDE autocomplete for BundledTheme while accepting custom theme names
+  defaultTheme: BundledTheme | (string & {})
   themes:
     | {
         light: BundledTheme
@@ -14,6 +15,7 @@ export interface CodeBlockShikiOptions extends CodeBlockOptions {
       }
     | null
     | undefined
+  customThemes: ThemeRegistration[] | null | undefined
 }
 /* v8 ignore stop -- @preserve */
 
@@ -24,6 +26,7 @@ export const CodeBlockShiki = CodeBlock.extend<CodeBlockShikiOptions>({
       defaultLanguage: null,
       defaultTheme: 'github-dark' as BundledTheme,
       themes: null,
+      customThemes: null,
     } as CodeBlockShikiOptions
   },
 
@@ -35,6 +38,7 @@ export const CodeBlockShiki = CodeBlock.extend<CodeBlockShikiOptions>({
         defaultLanguage: this.options.defaultLanguage,
         defaultTheme: this.options.defaultTheme,
         themes: this.options.themes,
+        customThemes: this.options.customThemes,
       }),
     ]
   },

--- a/lib/highlighter.ts
+++ b/lib/highlighter.ts
@@ -3,6 +3,7 @@ import type { Node as ProsemirrorNode } from '@tiptap/pm/model'
 import {
   type BundledLanguage,
   type BundledTheme,
+  type ThemeRegistration,
   bundledLanguages,
   bundledThemes,
   createHighlighter,
@@ -12,11 +13,17 @@ import {
 let highlighter: Highlighter | undefined
 let highlighterPromise: Promise<void> | undefined
 const loadingLanguages = new Set<BundledLanguage>()
-const loadingThemes = new Set<BundledTheme>()
+const loadingThemes = new Set<string>()
+const customThemeRegistry = new Map<string, ThemeRegistration>()
 
 type HighlighterOptions = {
-  themes: (BundledTheme | null | undefined)[]
+  themes: (BundledTheme | string | null | undefined)[]
   languages: (BundledLanguage | null | undefined)[]
+  customThemes?: ThemeRegistration[]
+}
+
+function isKnownTheme(theme: string): boolean {
+  return theme in bundledThemes || customThemeRegistry.has(theme)
 }
 
 export function resetHighlighter() {
@@ -24,6 +31,7 @@ export function resetHighlighter() {
   highlighterPromise = undefined
   loadingLanguages.clear()
   loadingThemes.clear()
+  customThemeRegistry.clear()
 }
 
 export function getShiki() {
@@ -35,12 +43,19 @@ export function getShiki() {
  */
 export function loadHighlighter(opts: HighlighterOptions) {
   if (!highlighter && !highlighterPromise) {
-    const themes = opts.themes.filter(
+    if (opts.customThemes) {
+      for (const t of opts.customThemes) {
+        if (t.name) customThemeRegistry.set(t.name, t)
+      }
+    }
+
+    const bundled = opts.themes.filter(
       (theme): theme is BundledTheme => !!theme && theme in bundledThemes,
     )
     const langs = opts.languages.filter(
       (lang): lang is BundledLanguage => !!lang && lang in bundledLanguages,
     )
+    const themes = [...bundled, ...customThemeRegistry.values()]
     highlighterPromise = createHighlighter({ themes, langs }).then((h) => {
       highlighter = h
     })
@@ -56,15 +71,16 @@ export function loadHighlighter(opts: HighlighterOptions) {
  * Loads a theme if it's valid and not yet loaded.
  * @returns true or false depending on if it got loaded.
  */
-export async function loadTheme(theme: BundledTheme) {
+export async function loadTheme(theme: BundledTheme | string) {
   if (
     highlighter &&
     !highlighter.getLoadedThemes().includes(theme) &&
     !loadingThemes.has(theme) &&
-    theme in bundledThemes
+    isKnownTheme(theme)
   ) {
     loadingThemes.add(theme)
-    await highlighter.loadTheme(theme)
+    const themeToLoad = customThemeRegistry.get(theme) ?? theme
+    await highlighter.loadTheme(themeToLoad as BundledTheme)
     loadingThemes.delete(theme)
     return true
   }
@@ -102,11 +118,12 @@ export async function initHighlighter({
   defaultTheme,
   defaultLanguage,
   themeModes,
+  customThemes,
 }: {
   doc: ProsemirrorNode
   name: string
   defaultLanguage: BundledLanguage | null | undefined
-  defaultTheme: BundledTheme
+  defaultTheme: BundledTheme | (string & {})
   themeModes:
     | {
         light: BundledTheme
@@ -114,6 +131,7 @@ export async function initHighlighter({
       }
     | null
     | undefined
+  customThemes?: ThemeRegistration[]
 }) {
   const codeBlocks = findChildren(doc, (node) => node.type.name === name)
 
@@ -127,7 +145,7 @@ export async function initHighlighter({
   ]
 
   if (!highlighter) {
-    const themesToLoad: BundledTheme[] = [...themes]
+    const themesToLoad: (BundledTheme | string)[] = [...themes]
     if (themeModes) {
       if (themeModes.light && !themesToLoad.includes(themeModes.light)) {
         themesToLoad.push(themeModes.light)
@@ -140,6 +158,7 @@ export async function initHighlighter({
     const loader = loadHighlighter({
       languages,
       themes: themesToLoad,
+      customThemes,
     })
     await loader
   } else {

--- a/lib/shiki-plugin.ts
+++ b/lib/shiki-plugin.ts
@@ -2,7 +2,12 @@ import { findChildren, type NodeWithPos } from '@tiptap/core'
 import type { Node as ProsemirrorNode } from '@tiptap/pm/model'
 import { Plugin, PluginKey, type PluginView } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
-import type { BundledLanguage, BundledTheme, TokensResult } from 'shiki'
+import type {
+  BundledLanguage,
+  BundledTheme,
+  ThemeRegistration,
+  TokensResult,
+} from 'shiki'
 import {
   getShiki,
   initHighlighter,
@@ -22,7 +27,7 @@ function getDecorations({
   doc: ProsemirrorNode
   name: string
   defaultLanguage: BundledLanguage | null | undefined
-  defaultTheme: BundledTheme
+  defaultTheme: BundledTheme | (string & {})
   themes:
     | {
         light: BundledTheme
@@ -134,10 +139,11 @@ export function ShikiPlugin({
   defaultLanguage,
   defaultTheme,
   themes,
+  customThemes,
 }: {
   name: string
   defaultLanguage: BundledLanguage | null | undefined
-  defaultTheme: BundledTheme
+  defaultTheme: BundledTheme | (string & {})
   themes:
     | {
         light: BundledTheme
@@ -145,6 +151,7 @@ export function ShikiPlugin({
       }
     | null
     | undefined
+  customThemes: ThemeRegistration[] | null | undefined
 }) {
   const shikiPlugin: Plugin<DecorationSet> = new Plugin({
     key: new PluginKey('shiki'),
@@ -171,6 +178,7 @@ export function ShikiPlugin({
             defaultLanguage,
             defaultTheme,
             themeModes: themes,
+            customThemes: customThemes ?? undefined,
           })
           const tr = view.state.tr.setMeta('shikiPluginForceDecoration', true)
           view.dispatch(tr)

--- a/lib/tests/custom-themes.test.ts
+++ b/lib/tests/custom-themes.test.ts
@@ -1,0 +1,80 @@
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import type { ThemeRegistration } from 'shiki'
+import { afterEach, expect, it, vi } from 'vitest'
+import { CodeBlockShiki } from '../code-block-shiki'
+import { resetHighlighter } from '../highlighter'
+
+afterEach(() => {
+  resetHighlighter()
+})
+
+const myCustomTheme: ThemeRegistration = {
+  name: 'my-custom-theme',
+  type: 'dark',
+  colors: {
+    'editor.background': '#1e1e2e',
+    'editor.foreground': '#cdd6f4',
+  },
+  tokenColors: [
+    {
+      scope: ['keyword', 'storage.type'],
+      settings: { foreground: '#cba6f7' },
+    },
+    {
+      scope: ['string'],
+      settings: { foreground: '#a6e3a1' },
+    },
+    {
+      scope: ['entity.name.function'],
+      settings: { foreground: '#89b4fa' },
+    },
+  ],
+}
+
+it('initializes tiptap with a custom theme', async () => {
+  const mount = document.createElement('div')
+  new Editor({
+    element: mount,
+    extensions: [
+      StarterKit.configure({ codeBlock: false }),
+      CodeBlockShiki.configure({
+        defaultTheme: 'my-custom-theme',
+        customThemes: [myCustomTheme],
+      }),
+    ],
+    content: `<pre><code class="language-ts">function foo() { return 'bar' }</code></pre>`,
+  })
+
+  await vi.waitFor(() => {
+    if (!mount.innerHTML.includes('style="color: #CBA6F7;"'))
+      throw new Error('custom theme keyword color not applied')
+  })
+
+  expect(mount.innerHTML).toContain('background-color: #1e1e2e')
+  expect(mount.innerHTML).toContain('color: #CBA6F7;')  // keyword: function, return
+  expect(mount.innerHTML).toContain('color: #89B4FA;')  // entity.name.function: foo
+  expect(mount.innerHTML).toContain('color: #A6E3A1;')  // string: 'bar'
+})
+
+it('uses custom theme alongside bundled theme', async () => {
+  const mount = document.createElement('div')
+  new Editor({
+    element: mount,
+    extensions: [
+      StarterKit.configure({ codeBlock: false }),
+      CodeBlockShiki.configure({
+        defaultTheme: 'github-dark',
+        customThemes: [myCustomTheme],
+      }),
+    ],
+    content: `<pre><code class="language-ts">const x = 1</code></pre>`,
+  })
+
+  await vi.waitFor(() => {
+    if (!mount.innerHTML.includes('background-color: #24292e'))
+      throw new Error('github-dark bg not applied')
+  })
+
+  expect(mount.innerHTML).toContain('background-color: #24292e')
+})


### PR DESCRIPTION
## Summary

Add `customThemes` option to `CodeBlockShikiOptions`, allowing users to pass `ThemeRegistration` objects for themes not included in Shiki's `bundledThemes`.

Closes #21

## Use Case

Using a custom Shiki theme (e.g. a terminal-style theme for markdown blocks) while keeping `github-dark` for regular code blocks. The extension already supports per-block themes via `node.attrs.theme`, but `loadTheme()` guards against non-bundled themes.

## Changes

- `CodeBlockShikiOptions.customThemes: ThemeRegistration[] | null`
- Custom themes are registered during highlighter initialization
- `loadTheme()` accepts custom theme names alongside bundled themes
- `defaultTheme` type widened to `BundledTheme | (string & {})` to accept custom theme names while preserving IDE autocomplete for bundled themes

## Usage

\`\`\`ts
import type { ThemeRegistration } from 'shiki'

const myTheme: ThemeRegistration = {
  name: 'my-theme',
  type: 'dark',
  colors: { 'editor.background': '#1e1e2e' },
  tokenColors: [...]
}

CodeBlockShiki.configure({
  defaultTheme: 'my-theme',
  customThemes: [myTheme],
})
\`\`\`

## Tests

- Custom theme initialization and token color verification
- Custom theme alongside bundled theme (no regression)